### PR TITLE
Implements improvements to allow loading extracted (unbundled) libraries

### DIFF
--- a/buildSrc/src/main/kotlin/CodeGenerationPlugin.kt
+++ b/buildSrc/src/main/kotlin/CodeGenerationPlugin.kt
@@ -52,7 +52,7 @@ class CodeGenerationPlugin : Plugin<Project> {
     private fun Project.registerSoGenerationTasks(generateEnumsTask: TaskProvider<out Task>) {
         val soFile = buildDir.resolve("generated")
             .resolve("libs")
-            .resolve("osxkeychain.so")
+            .resolve("osxkeychain.dylib")
         val sourceSets = extensions.findByType(JavaPluginExtension::class.java)!!.sourceSets
 
         // generate the .h header


### PR DESCRIPTION
This PR improves the loading of the shared object `loadSharedObject()` by adding the following cases:
- Try to load the library from the standard paths expected by [Conveyor](https://conveyor.hydraulic.dev/). See below for more information.
- Try to load the library from `java.library.path` by using `System.loadLibrary()`.
- Fallback to the previous method of extracting the shared object from the JAR and loading it from a temporary directory.

Why do we need the first method to load the library in a manner compatible with Conveyor? Because it's been observed that sometimes the `System.loadLibrary()` may not be able to find some libraries in the `java.library.path`. Because of that we first try to load the library by using `System.load()` in the expected paths if the app is running under Conveyor environment (`System.getProperty("app.dir")` is not `null`), and then we fallback to other methods.

Also notice that we change the extension of the shared object library from `.so` to `.dylib` as otherwise Conveyor is not able to recognize it. From a practical point of view both file extensions refer to the same file format.